### PR TITLE
fix: support read only root filesystem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ workflows:
               only:
                 - main
                 - chore/ci-helm
+                - fix/rorfs
       - build_and_publish_chart:
           requires:
             - lint
@@ -67,3 +68,4 @@ workflows:
               only:
                 - main
                 - chore/ci-helm
+                - fix/rorfs

--- a/charts/connection-manager/Chart.yaml
+++ b/charts/connection-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.3.1"
 description: Connection Manager Helm chart for Kubernetes
 name: connection-manager
-version: 1.3.3-rorfs.0
+version: 1.3.3-rorfs.1
 keywords:
   - connection-manager
 sources:

--- a/charts/connection-manager/Chart.yaml
+++ b/charts/connection-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.3.1"
 description: Connection Manager Helm chart for Kubernetes
 name: connection-manager
-version: 1.3.2
+version: 1.3.3
 keywords:
   - connection-manager
 sources:

--- a/charts/connection-manager/Chart.yaml
+++ b/charts/connection-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.3.1"
 description: Connection Manager Helm chart for Kubernetes
 name: connection-manager
-version: 1.3.3
+version: 1.3.3-rorfs.0
 keywords:
   - connection-manager
 sources:

--- a/charts/connection-manager/Chart.yaml
+++ b/charts/connection-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.3.1"
 description: Connection Manager Helm chart for Kubernetes
 name: connection-manager
-version: 1.3.3-rorfs.1
+version: 1.3.3-rorfs.2
 keywords:
   - connection-manager
 sources:

--- a/charts/connection-manager/templates/api-configmap.yaml
+++ b/charts/connection-manager/templates/api-configmap.yaml
@@ -7,7 +7,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}   
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": {{ .Values.migrations.deletePolicy }}     
 data:
   tlsClientCSRParameters.json: {{ .Values.config.tlsClientCSRParametersData | quote }}
   tlsServerCSRParameters.json: {{ .Values.config.tlsServerCSRParametersData | quote }}

--- a/charts/connection-manager/templates/api-deployment.yaml
+++ b/charts/connection-manager/templates/api-deployment.yaml
@@ -28,6 +28,8 @@ spec:
       {{- end }}
       containers:
         - name: connection-manager-api
+          securityContext:
+            readOnlyRootFilesystem: true
           {{- with .Values.api }}
           image: "{{ .image.name }}:{{ .image.version }}"
           ports:

--- a/charts/connection-manager/templates/api-secret.yaml
+++ b/charts/connection-manager/templates/api-secret.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secret   
+  name: {{ .Release.Name }}-secret
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": {{ .Values.migrations.deletePolicy }}     
 type: Opaque
 data:
   dummy: RFVNTVk=

--- a/charts/connection-manager/templates/migrations.yaml
+++ b/charts/connection-manager/templates/migrations.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
   annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": {{ .Values.migrations.deletePolicy }}
 spec:
   template:

--- a/charts/connection-manager/templates/migrations.yaml
+++ b/charts/connection-manager/templates/migrations.yaml
@@ -27,6 +27,8 @@ spec:
       initContainers:
       - name: wait-for-db
         image: busybox:1.36
+        securityContext:
+          readOnlyRootFilesystem: true
         command:
         - /bin/sh
         - -c
@@ -42,6 +44,8 @@ spec:
           value: {{ .Values.db.host }}
       containers:
       - name: db-migration
+        securityContext:
+          readOnlyRootFilesystem: true
           {{- with .Values.api }}
         image: "{{ .image.name }}:{{ .image.version }}"
           {{- end }}

--- a/charts/connection-manager/templates/migrations.yaml
+++ b/charts/connection-manager/templates/migrations.yaml
@@ -56,6 +56,8 @@ spec:
         - run
         - {{ default "migrate-and-seed" .Values.migrations.script }}
         env:
+        - name: NPM_CONFIG_UPDATE_NOTIFIER
+          value: 'false'
         - name: DATABASE_HOST
           value: {{ .Values.db.host }}
         - name: DATABASE_USER

--- a/charts/connection-manager/templates/service-account.yaml
+++ b/charts/connection-manager/templates/service-account.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
   labels:
     app.kubernetes.io/component: api
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": {{ .Values.migrations.deletePolicy }}    
 {{ include "connection-manager.labels" . | indent 4 }}
 
 {{- end -}}

--- a/charts/connection-manager/templates/tests/api-test-runner.yaml
+++ b/charts/connection-manager/templates/tests/api-test-runner.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app.kubernetes.io/component: test-api
 {{ include "connection-manager.labels" . | indent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-weight: {{ .Values.tests.api.weight | quote }}
+    helm.sh/hook-delete-policy: {{ .Values.tests.api.deletePolicy }}
 spec:
   restartPolicy: Never
   containers:

--- a/charts/connection-manager/templates/ui-deployment.yaml
+++ b/charts/connection-manager/templates/ui-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       containers:
         - name: connection-manager-ui
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
           env:
             - name: API_BASE_URL
               value: {{ .Values.api.url | quote }}


### PR DESCRIPTION
- this intentionally restores the annotations removed by 7f0a774c9b0dc8e950c8402fe42e9155e6e3ae7d, as they are important when the the job exists from previous ArgoCD sync.

CC @kirgene 